### PR TITLE
Add GitHub Skills activity to registration system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Purpose
Adds the missing **GitHub Skills** activity that was announced by the principal but not available for student registration.

## 📝 Changes
- Added GitHub Skills activity to the activities database
- **Schedule**: Mondays and Wednesdays, 3:30 PM - 5:00 PM
- **Capacity**: 25 participants (to accommodate high student interest)
- **Description**: Includes reference to GitHub Certifications program for college applications

## ✅ Testing
- [x] Activity appears in `/activities` API endpoint
- [x] Students can successfully sign up for the activity
- [x] Activity displays correctly in the web interface
- [x] All existing activities remain intact

## 🔗 Related Issue
Closes #6

## ⏱️ Urgency
This is time-sensitive as registrations close by the end of this week per the principal's announcement.